### PR TITLE
iOS 포토피커 로직 구현

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/androidMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -10,14 +10,15 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
 import coil3.Uri
 import coil3.toUri
+import kotlinx.coroutines.CoroutineScope
 
 @Composable
 actual fun rememberImagePickerLauncher(
+    onResult: (List<Any>) -> Unit,
+    scope: CoroutineScope?,
     selectionMode: SelectionMode,
-    onResult: (List<Uri>) -> Unit,
 ): ImagePickerLauncher {
     return when (selectionMode) {
         SelectionMode.Single -> {
@@ -54,9 +55,8 @@ private fun singlePhotoPicker(
 
 @Composable
 private fun multiplePhotoPicker(
-    onResult: (List<Uri>) -> Unit,
+    onResult: (List<Any>) -> Unit,
 ): ImagePickerLauncher {
-    val context = LocalContext.current
     val multiplePhotoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(),
         onResult = { uriList ->
@@ -74,7 +74,7 @@ private fun multiplePhotoPicker(
 }
 
 actual class ImagePickerLauncher actual constructor(
-    private val onLaunch: () -> Unit
+    private val onLaunch: () -> Unit,
 ) {
     actual fun launch() {
         onLaunch()

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
@@ -14,11 +14,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.Uri
 import coil3.compose.AsyncImage
-import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import io.github.aakira.napier.Napier
 import org.moneyking.imagepicker.theme.Gray200
 
 @Composable
@@ -46,19 +44,39 @@ fun ImageCard(
                         .build(),
                     contentDescription = "Gallery Image",
                     contentScale = ContentScale.Crop,
-                    onState = { state ->
-                        when (state) {
-                            is AsyncImagePainter.State.Success -> {
-                                Napier.d("load success")
-                            }
+                ),
+                contentScale = ContentScale.Crop,
+                contentDescription = "Image Card",
+            )
+        }
+    }
+}
 
-                            is AsyncImagePainter.State.Error -> {
-                                Napier.d("${state.result.throwable}")
-                            }
-
-                            else -> {}
-                        }
-                    }
+@Composable
+fun ImageCard(
+    imageUrl: ByteArray,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Gray200),
+    ) {
+        Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            AsyncImage(
+                modifier = Modifier.fillMaxSize(),
+                model = AsyncImage(
+                    model = ImageRequest.Builder(LocalPlatformContext.current)
+                        .data(imageUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = "Gallery Image",
+                    contentScale = ContentScale.Crop,
                 ),
                 contentScale = ContentScale.Crop,
                 contentDescription = "Image Card",

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -6,7 +6,6 @@
 package org.moneyking.imagepicker.launcher
 
 import androidx.compose.runtime.Composable
-import coil3.Uri
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -17,8 +16,9 @@ import kotlinx.coroutines.CoroutineScope
  */
 @Composable
 expect fun rememberImagePickerLauncher(
+    onResult: (List<Any>) -> Unit,
+    scope: CoroutineScope?,
     selectionMode: SelectionMode = SelectionMode.Single,
-    onResult: (List<Uri>) -> Unit,
 ): ImagePickerLauncher
 
 sealed class SelectionMode {
@@ -27,7 +27,7 @@ sealed class SelectionMode {
 }
 
 expect class ImagePickerLauncher(
-    onLaunch: () -> Unit
+    onLaunch: () -> Unit,
 ) {
     fun launch()
 }

--- a/composeApp/src/desktopMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/desktopMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -6,18 +6,19 @@
 package org.moneyking.imagepicker.launcher
 
 import androidx.compose.runtime.Composable
-import coil3.Uri
+import kotlinx.coroutines.CoroutineScope
 
 @Composable
 actual fun rememberImagePickerLauncher(
+    onResult: (List<Any>) -> Unit,
+    scope: CoroutineScope?,
     selectionMode: SelectionMode,
-    onResult: (List<Uri>) -> Unit,
 ): ImagePickerLauncher {
     TODO()
 }
 
 actual class ImagePickerLauncher actual constructor(
-    onLaunch: () -> Unit
+    private val onLaunch: () -> Unit,
 ) {
     actual fun launch() {
         TODO()

--- a/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -6,20 +6,117 @@
 package org.moneyking.imagepicker.launcher
 
 import androidx.compose.runtime.Composable
-import coil3.Uri
+import androidx.compose.runtime.remember
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.refTo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerConfigurationSelectionOrdered
+import platform.PhotosUI.PHPickerFilter
+import platform.PhotosUI.PHPickerResult
+import platform.PhotosUI.PHPickerViewController
+import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
+import platform.UIKit.UIApplication
+import platform.darwin.NSObject
+import platform.darwin.dispatch_get_main_queue
+import platform.darwin.dispatch_group_create
+import platform.darwin.dispatch_group_enter
+import platform.darwin.dispatch_group_leave
+import platform.darwin.dispatch_group_notify
+import platform.posix.memcpy
 
 @Composable
 actual fun rememberImagePickerLauncher(
+    onResult: (List<Any>) -> Unit,
+    scope: CoroutineScope?,
     selectionMode: SelectionMode,
-    onResult: (List<Uri>) -> Unit,
 ): ImagePickerLauncher {
-    TODO()
+    @OptIn(ExperimentalForeignApi::class)
+    val delegate =
+        object : NSObject(), PHPickerViewControllerDelegateProtocol {
+            override fun picker(
+                picker: PHPickerViewController,
+                didFinishPicking: List<*>,
+            ) {
+                picker.dismissViewControllerAnimated(flag = true, completion = null)
+                @Suppress("UNCHECKED_CAST")
+                val results = didFinishPicking as List<PHPickerResult>
+
+                val dispatchGroup = dispatch_group_create()
+                val imageData = mutableListOf<ByteArray>()
+
+                for (result in results) {
+                    dispatch_group_enter(dispatchGroup)
+                    result.itemProvider.loadDataRepresentationForTypeIdentifier(
+                        typeIdentifier = "public.image",
+                    ) { nsData, _ ->
+                        scope?.launch(Dispatchers.Main) {
+                            nsData?.let {
+                                val bytes = ByteArray(it.length.toInt())
+                                memcpy(bytes.refTo(0), it.bytes, it.length)
+                                imageData.add(bytes)
+                            }
+                            dispatch_group_leave(dispatchGroup)
+                        }
+                    }
+                }
+
+                dispatch_group_notify(dispatchGroup, dispatch_get_main_queue()) {
+                    scope?.launch(Dispatchers.Main) {
+                        onResult(imageData)
+                    }
+                }
+            }
+        }
+
+    return remember {
+        ImagePickerLauncher(
+            onLaunch = {
+                val pickerController = createPHPickerViewController(delegate, selectionMode)
+                UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+                    pickerController,
+                    true,
+                    null,
+                )
+            },
+        )
+    }
+}
+
+private fun createPHPickerViewController(
+    delegate: PHPickerViewControllerDelegateProtocol,
+    selection: SelectionMode,
+): PHPickerViewController {
+    val pickerViewController =
+        PHPickerViewController(
+            configuration =
+            when (selection) {
+                is SelectionMode.Multiple ->
+                    PHPickerConfiguration().apply {
+                        // selectionLimit = 0 -> infinite
+                        setSelectionLimit(selectionLimit = 0)
+                        setFilter(filter = PHPickerFilter.imagesFilter)
+                        setSelection(selection = PHPickerConfigurationSelectionOrdered)
+                    }
+
+                SelectionMode.Single ->
+                    PHPickerConfiguration().apply {
+                        setSelectionLimit(selectionLimit = 1)
+                        setFilter(filter = PHPickerFilter.imagesFilter)
+                        setSelection(selection = PHPickerConfigurationSelectionOrdered)
+                    }
+            },
+        )
+    pickerViewController.delegate = delegate
+    return pickerViewController
 }
 
 actual class ImagePickerLauncher actual constructor(
-    onLaunch: () -> Unit
+    private val onLaunch: () -> Unit,
 ) {
     actual fun launch() {
-        TODO()
+        onLaunch()
     }
 }


### PR DESCRIPTION
- peekaboo 라이브러리를 참고하여, iOS actual ImagePickerLauncher 구현하였습니다

- [Compose API 가이드라인](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-component-api-guidelines.md#parameters-order)에 맞게 composable 함수 내에 required parameter 를 optional parameter 보다 앞쪽으로 이동 시켰습니다

- 누락된 trailing comma 추가하였습니다

- remeberImagePickerLauncher 에서 onResult 의 결과로 Uri type 과 byteArray type 을 둘다 받는 관계로, type을 Any 로 변경 하였고, named parameter 네이밍을 범용적으로 변경하였습니다(uri, uriList -> imageData, imageDataList)

TODO) 코드의 구현 방식을 다른 방향으로 바꿔봐도(Swift 사용하는 방향으로 라던지) 좋을 것 같습니다 