### PR TITLE
화면 가로 모드 대응

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/App.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -33,6 +35,7 @@ import org.moneyking.imagepicker.component.ImageCard
 import org.moneyking.imagepicker.component.ImagePickerButton
 import org.moneyking.imagepicker.launcher.SelectionMode
 import org.moneyking.imagepicker.launcher.rememberImagePickerLauncher
+import org.moneyking.imagepicker.util.extension.aspectRatioBasedOnOrientation
 import org.moneyking.imagepicker.util.newImageLoader
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalCoilApi::class)
@@ -70,7 +73,10 @@ fun App(
             SnackbarHost(snackbarHostState)
         }) { innerPadding ->
             Column(
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
@@ -85,14 +91,20 @@ fun App(
                             is Uri -> {
                                 ImageCard(
                                     imageUrl = image,
-                                    modifier = Modifier.fillMaxSize(),
+                                    modifier = Modifier
+                                        .aspectRatioBasedOnOrientation(1f)
+                                        .padding(16.dp)
+                                        .align(Alignment.CenterHorizontally),
                                 )
                             }
 
                             is ByteArray -> {
                                 ImageCard(
                                     imageUrl = image,
-                                    modifier = Modifier.fillMaxSize(),
+                                    modifier = Modifier
+                                        .aspectRatioBasedOnOrientation(1f)
+                                        .padding(16.dp)
+                                        .align(Alignment.CenterHorizontally),
                                 )
                             }
 
@@ -146,6 +158,7 @@ fun App(
                         .height(56.dp)
                         .padding(horizontal = 24.dp),
                 )
+                Spacer(modifier = Modifier.height(32.dp))
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
@@ -1,10 +1,6 @@
 package org.moneyking.imagepicker.component
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -25,30 +21,23 @@ fun ImageCard(
     modifier: Modifier = Modifier,
 ) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier = modifier,
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = Gray200),
     ) {
-        Column(
-            modifier = modifier,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            AsyncImage(
-                modifier = Modifier.fillMaxSize(),
-                model = AsyncImage(
-                    model = ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(imageUrl)
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "Gallery Image",
-                    contentScale = ContentScale.Crop,
-                ),
+        AsyncImage(
+            modifier = Modifier.fillMaxSize(),
+            model = AsyncImage(
+                model = ImageRequest.Builder(LocalPlatformContext.current)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = "Gallery Image",
                 contentScale = ContentScale.Crop,
-                contentDescription = "Image Card",
-            )
-        }
+            ),
+            contentScale = ContentScale.Crop,
+            contentDescription = "Image Card",
+        )
     }
 }
 
@@ -58,29 +47,22 @@ fun ImageCard(
     modifier: Modifier = Modifier,
 ) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier = modifier,
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = Gray200),
     ) {
-        Column(
-            modifier = modifier,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            AsyncImage(
-                modifier = Modifier.fillMaxSize(),
-                model = AsyncImage(
-                    model = ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(imageUrl)
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "Gallery Image",
-                    contentScale = ContentScale.Crop,
-                ),
+        AsyncImage(
+            modifier = Modifier.fillMaxSize(),
+            model = AsyncImage(
+                model = ImageRequest.Builder(LocalPlatformContext.current)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = "Gallery Image",
                 contentScale = ContentScale.Crop,
-                contentDescription = "Image Card",
-            )
-        }
+            ),
+            contentScale = ContentScale.Crop,
+            contentDescription = "Image Card",
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/util/extension/Modifier.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/util/extension/Modifier.kt
@@ -1,0 +1,38 @@
+package org.moneyking.imagepicker.util.extension
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+
+fun Modifier.aspectRatioBasedOnOrientation(aspectRatio: Float): Modifier {
+    return this.then(
+        object : LayoutModifier {
+            override fun MeasureScope.measure(measurable: Measurable, constraints: Constraints): MeasureResult {
+                val width = constraints.maxWidth
+                val height = constraints.maxHeight
+
+                val targetWidth: Int
+                val targetHeight: Int
+
+                if (width <= height) {
+                    targetWidth = width
+                    targetHeight = (width / aspectRatio).toInt()
+                } else {
+                    targetHeight = height
+                    targetWidth = (height * aspectRatio).toInt()
+                }
+
+                val placeable = measurable.measure(
+                    Constraints.fixed(targetWidth, targetHeight),
+                )
+
+                return layout(placeable.width, placeable.height) {
+                    placeable.placeRelative(0, 0)
+                }
+            }
+        },
+    )
+}


### PR DESCRIPTION
- column verticalScroll 활성화(화면의 하단 버튼이 짤리지 않도록)
- ImageCard 가로, 세로 비율 1대1 로 고정

|이전 1|이전 2|
|:-----:|:-----:|
|<img width="360" src="https://github.com/KwonDae/ImagePicker/assets/51016231/b0af1e98-1176-425a-b9a2-9255d4f786bc">|

|이후 1|이후 2|
|:-----:|:-----:|
|<img width="360" src="https://github.com/KwonDae/ImagePicker/assets/51016231/13e85e12-446f-4ba2-bf20-47363080a507">|<img width="360" src="https://github.com/KwonDae/ImagePicker/assets/51016231/c6dcb465-1f41-4c4b-9fe4-5ac0f02000c7">|