### PR TITLE
Decompose 라이브러리 적용

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
     id ("dev.icerock.mobile.multiplatform-resources")
+    alias(libs.plugins.kotlinSerialization)
 }
 
 kotlin {
@@ -47,11 +48,13 @@ kotlin {
             implementation(libs.compose.ui.tooling.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.ktor.engine.android)
+            implementation(libs.decompose)
         }
 
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.foundation)
+            implementation(compose.materialIconsExtended)
             implementation(compose.material3)
             implementation(compose.ui)
             @OptIn(ExperimentalComposeLibrary::class)
@@ -59,6 +62,9 @@ kotlin {
             implementation(libs.coil.compose)
             implementation(libs.napier)
             implementation(libs.coil.network)
+            implementation(libs.decompose)
+            implementation(libs.decompose.jetbrains)
+            implementation(libs.zoomable)
         }
 
         iosMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/org/moneyking/imagepicker/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/moneyking/imagepicker/MainActivity.kt
@@ -3,24 +3,19 @@ package org.moneyking.imagepicker
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import org.jetbrains.compose.components.resources.BuildConfig
+import com.arkivanov.decompose.ExperimentalDecomposeApi
+import com.arkivanov.decompose.retainedComponent
+import org.moneyking.imagepicker.navigation.RootComponent
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalDecomposeApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        val root = retainedComponent {
+            RootComponent(it)
+        }
         setContent {
-            App()
+            App(root)
         }
     }
-}
-
-@Preview
-@Composable
-fun AppAndroidPreview() {
-    App(
-        debug = BuildConfig.DEBUG
-    )
 }

--- a/composeApp/src/androidMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/androidMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -21,7 +21,9 @@ import coil3.annotation.ExperimentalCoilApi
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -61,9 +63,11 @@ private fun singlePhotoPicker(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri ->
             uri?.let {
-                scope.launch {
+                scope.launch(Dispatchers.IO) {
                     val byteArray = createByteArrayFromUri(context, it)
-                    onResult(byteArray)
+                    withContext(Dispatchers.Main) {
+                        onResult(byteArray)
+                    }
                 }
                 // uriToByteArray(contentResolver, it)?.let { onResult(it) }
             }
@@ -89,11 +93,13 @@ private fun multiplePhotoPicker(
     val multiplePhotoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(),
         onResult = { uriList ->
-            scope.launch {
+            scope.launch(Dispatchers.IO) {
                 val byteArrayList = uriList.map { uri ->
                     createByteArrayFromUri(context, uri)
                 }
-                onResult(byteArrayList)
+                withContext(Dispatchers.Main) {
+                    onResult(byteArrayList)
+                }
             }
 //            onResult(uriList.map { uri ->
 //                uriToByteArray(contentResolver, uri)!!

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/App.kt
@@ -1,150 +1,29 @@
 package org.moneyking.imagepicker
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import coil3.Uri
-import coil3.annotation.ExperimentalCoilApi
-import coil3.compose.setSingletonImageLoaderFactory
-import dev.icerock.moko.resources.compose.stringResource
-import org.moneyking.imagepicker.component.HorizontalPagerIndicator
-import org.moneyking.imagepicker.component.ImageCard
-import org.moneyking.imagepicker.component.ImagePickerButton
-import org.moneyking.imagepicker.launcher.SelectionMode
-import org.moneyking.imagepicker.launcher.rememberImagePickerLauncher
-import org.moneyking.imagepicker.util.newImageLoader
+import com.arkivanov.decompose.extensions.compose.jetbrains.stack.Children
+import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.slide
+import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.stackAnimation
+import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
+import org.moneyking.imagepicker.navigation.RootComponent
+import org.moneyking.imagepicker.screen.DetailScreen
+import org.moneyking.imagepicker.screen.MainScreen
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalCoilApi::class)
 @Composable
-fun App(
-    debug: Boolean = false
-) {
-    setSingletonImageLoaderFactory { context ->
-        newImageLoader(context, debug)
-    }
-    val scope = rememberCoroutineScope()
-    var images by remember { mutableStateOf(listOf<Any>()) }
-    val singlePhotoPicker = rememberImagePickerLauncher(
-        selectionMode = SelectionMode.Single,
-        scope = scope,
-        onResult = { imageData ->
-            images = imageData
-        }
-    )
-    val multiplePhotoPicker = rememberImagePickerLauncher(
-        selectionMode = SelectionMode.Multiple,
-        scope = scope,
-        onResult = { imageDataList ->
-            images = imageDataList
-        }
-    )
-
+fun App(root: RootComponent) {
     MaterialTheme {
-        val snackbarHostState = remember { SnackbarHostState() }
-        val pageCount = images.size
-        val pagerState = rememberPagerState(pageCount = { pageCount })
-        val pagerHeight = 320.dp
-
-        Scaffold(snackbarHost = {
-            SnackbarHost(snackbarHostState)
-        }) { innerPadding ->
-            Column(
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                if (images.isNotEmpty()) {
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier.height(pagerHeight),
-                        contentPadding = PaddingValues(horizontal = 32.dp),
-                    ) { index ->
-                        val image = images[index]
-                        when (image) {
-                            is Uri -> {
-                                ImageCard(
-                                    imageUrl = image,
-                                    modifier = Modifier.fillMaxSize(),
-                                )
-                            }
-
-                            is ByteArray -> {
-                                ImageCard(
-                                    imageUrl = image,
-                                    modifier = Modifier.fillMaxSize(),
-                                )
-                            }
-
-                            else -> {
-                                require(image is Uri || image is ByteArray) {
-                                    "Unsupported image type: ${image::class}"
-                                }
-                            }
-                        }
-                    }
-                    if (pageCount > 1) {
-                        HorizontalPagerIndicator(
-                            pageCount = pageCount,
-                            currentPage = pagerState.currentPage,
-                            targetPage = pagerState.targetPage,
-                            currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(32.dp))
-                }
-
-                ImagePickerButton(
-                    onClick = {
-                        singlePhotoPicker.launch()
-                    },
-                    text = stringResource(MR.strings.pick_single_image),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .padding(horizontal = 24.dp),
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                ImagePickerButton(
-                    onClick = {
-                        multiplePhotoPicker.launch()
-                    },
-                    text = stringResource(MR.strings.pick_multiple_images),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .padding(horizontal = 24.dp),
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                ImagePickerButton(
-                    onClick = {
-                        images = emptyList()
-                    },
-                    text = stringResource(MR.strings.reset),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .padding(horizontal = 24.dp),
+        val childStack by root.childStack.subscribeAsState()
+        Children(
+            stack = childStack,
+            animation = stackAnimation(slide())
+        ) { child ->
+            when (val instance = child.instance) {
+                is RootComponent.Child.MainScreen -> MainScreen(instance.component)
+                is RootComponent.Child.DetailScreen -> DetailScreen(
+                    image = instance.component.image,
+                    component = instance.component,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
@@ -12,16 +12,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import coil3.Uri
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import dev.icerock.moko.resources.compose.stringResource
+import org.moneyking.imagepicker.MR
 import org.moneyking.imagepicker.theme.Gray200
 
 @Composable
 fun ImageCard(
-    imageUrl: Uri,
+    image: ByteArray,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -36,50 +37,13 @@ fun ImageCard(
             verticalArrangement = Arrangement.Center,
         ) {
             AsyncImage(
+                model = ImageRequest.Builder(LocalPlatformContext.current)
+                    .data(image)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.image_card),
                 modifier = Modifier.fillMaxSize(),
-                model = AsyncImage(
-                    model = ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(imageUrl)
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "Gallery Image",
-                    contentScale = ContentScale.Crop,
-                ),
                 contentScale = ContentScale.Crop,
-                contentDescription = "Image Card",
-            )
-        }
-    }
-}
-
-@Composable
-fun ImageCard(
-    imageUrl: ByteArray,
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Gray200),
-    ) {
-        Column(
-            modifier = modifier,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            AsyncImage(
-                modifier = Modifier.fillMaxSize(),
-                model = AsyncImage(
-                    model = ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(imageUrl)
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "Gallery Image",
-                    contentScale = ContentScale.Crop,
-                ),
-                contentScale = ContentScale.Crop,
-                contentDescription = "Image Card",
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/component/ImageCard.kt
@@ -1,10 +1,6 @@
 package org.moneyking.imagepicker.component
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -26,25 +22,18 @@ fun ImageCard(
     modifier: Modifier = Modifier,
 ) {
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier = modifier,
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(containerColor = Gray200),
     ) {
-        Column(
-            modifier = modifier,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalPlatformContext.current)
-                    .data(image)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = stringResource(MR.strings.image_card),
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop,
-            )
-        }
+        AsyncImage(
+            model = ImageRequest.Builder(LocalPlatformContext.current)
+                .data(image)
+                .crossfade(true)
+                .build(),
+            contentDescription = stringResource(MR.strings.image_card),
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 @Composable
 expect fun rememberImagePickerLauncher(
     onResult: (List<ByteArray>) -> Unit,
-    scope: CoroutineScope?,
+    scope: CoroutineScope,
     selectionMode: SelectionMode = SelectionMode.Single,
 ): ImagePickerLauncher
 

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.CoroutineScope
  */
 @Composable
 expect fun rememberImagePickerLauncher(
-    onResult: (List<Any>) -> Unit,
+    onResult: (List<ByteArray>) -> Unit,
     scope: CoroutineScope?,
     selectionMode: SelectionMode = SelectionMode.Single,
 ): ImagePickerLauncher

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/DetailScreenComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/DetailScreenComponent.kt
@@ -1,0 +1,13 @@
+package org.moneyking.imagepicker.navigation
+
+import com.arkivanov.decompose.ComponentContext
+
+class DetailScreenComponent(
+    val image: ByteArray,
+    componentContext: ComponentContext,
+    private val onGoBack: () -> Unit,
+): ComponentContext by componentContext {
+    fun goBack() {
+        onGoBack()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/MainScreenComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/MainScreenComponent.kt
@@ -1,0 +1,35 @@
+package org.moneyking.imagepicker.navigation
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import io.github.aakira.napier.Napier
+
+class MainScreenComponent(
+    componentContext: ComponentContext,
+    private val onNavigateToDetail: (ByteArray) -> Unit,
+): ComponentContext by componentContext {
+    private var _imageList = MutableValue(emptyList<ByteArray>())
+    val imageList: Value<List<ByteArray>> = _imageList
+
+    private var _index = MutableValue(-1)
+    val index: Value<Int> = _index
+
+    fun onEvent(event: MainScreenEvent) {
+        when(event) {
+            is MainScreenEvent.ClickImageCard -> {
+                onNavigateToDetail(imageList.value[index.value])
+            }
+
+            is MainScreenEvent.UpdateImageIndex -> {
+                _index.value = event.index
+                Napier.d("${index.value}")
+            }
+
+            is MainScreenEvent.UpdateImageList -> {
+                _imageList.value = event.imageList
+                Napier.d("${imageList.value}")
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/MainScreenEvent.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/MainScreenEvent.kt
@@ -1,0 +1,7 @@
+package org.moneyking.imagepicker.navigation
+
+sealed interface MainScreenEvent {
+    data class ClickImageCard(val image: Any): MainScreenEvent
+    data class UpdateImageIndex(val index: Int): MainScreenEvent
+    data class UpdateImageList(val imageList: List<ByteArray>): MainScreenEvent
+}

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/navigation/RootComponent.kt
@@ -1,0 +1,83 @@
+package org.moneyking.imagepicker.navigation
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.ExperimentalDecomposeApi
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.pushNew
+import kotlinx.serialization.Serializable
+
+class RootComponent(
+    componentContext: ComponentContext,
+) : ComponentContext by componentContext {
+    private val navigation = StackNavigation<Configuration>()
+
+    val childStack = childStack(
+        source = navigation,
+        serializer = Configuration.serializer(),
+        initialConfiguration = Configuration.MainScreen,
+        handleBackButton = true,
+        childFactory = ::createChild,
+    )
+
+    @OptIn(ExperimentalDecomposeApi::class)
+    private fun createChild(
+        config: Configuration,
+        context: ComponentContext,
+    ): Child {
+        return when (config) {
+            Configuration.MainScreen -> {
+                Child.MainScreen(
+                    MainScreenComponent(
+                        componentContext = context,
+                        onNavigateToDetail = { byteArray ->
+                            navigation.pushNew(Configuration.DetailScreen(image = byteArray))
+                        }
+                    )
+                )
+            }
+
+            is Configuration.DetailScreen -> {
+                Child.DetailScreen(
+                    DetailScreenComponent(
+                        image = config.image,
+                        componentContext = context,
+                        onGoBack = {
+                            navigation.pop()
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    sealed class Child {
+        data class MainScreen(val component: MainScreenComponent) : Child()
+        data class DetailScreen(val component: DetailScreenComponent) : Child()
+    }
+
+    @Serializable
+    sealed class Configuration {
+        @Serializable
+        data object MainScreen : Configuration()
+
+        @Serializable
+        data class DetailScreen(
+            val image: ByteArray,
+        ) : Configuration() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other == null || this::class != other::class) return false
+
+                other as DetailScreen
+
+                return image.contentEquals(other.image)
+            }
+
+            override fun hashCode(): Int {
+                return image.contentHashCode()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/DetailScreen.kt
@@ -1,0 +1,85 @@
+package org.moneyking.imagepicker.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBackIos
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.mxalbert.zoomable.Zoomable
+import dev.icerock.moko.resources.compose.fontFamilyResource
+import dev.icerock.moko.resources.compose.stringResource
+import org.moneyking.imagepicker.MR
+import org.moneyking.imagepicker.navigation.DetailScreenComponent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailScreen(
+    image: ByteArray,
+    component: DetailScreenComponent,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(MR.strings.detail),
+                        fontFamily = fontFamilyResource(MR.fonts.Pretendard.semiBold),
+                        fontWeight = FontWeight.SemiBold,
+                        fontStyle = FontStyle.Normal,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            component.goBack()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBackIos,
+                            contentDescription = stringResource(MR.strings.back_button),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            Zoomable {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalPlatformContext.current)
+                        .data(image)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = stringResource(MR.strings.detail_image),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.Center),
+                    contentScale = ContentScale.Fit,
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/MainScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -40,6 +42,7 @@ import org.moneyking.imagepicker.launcher.SelectionMode
 import org.moneyking.imagepicker.launcher.rememberImagePickerLauncher
 import org.moneyking.imagepicker.navigation.MainScreenComponent
 import org.moneyking.imagepicker.navigation.MainScreenEvent
+import org.moneyking.imagepicker.util.extension.aspectRatioBasedOnOrientation
 import org.moneyking.imagepicker.util.newImageLoader
 
 @OptIn(
@@ -96,7 +99,10 @@ fun MainScreen(
             }
         ) { innerPadding ->
             Column(
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
@@ -112,7 +118,9 @@ fun MainScreen(
                         ImageCard(
                             image = image,
                             modifier = Modifier
-                                .fillMaxSize()
+                                .aspectRatioBasedOnOrientation(1f)
+                                .padding(16.dp)
+                                .align(Alignment.CenterHorizontally)
                                 .clickable {
                                     component.onEvent(MainScreenEvent.UpdateImageIndex(index))
                                     component.onEvent(MainScreenEvent.ClickImageCard(image))
@@ -162,6 +170,7 @@ fun MainScreen(
                         .height(56.dp)
                         .padding(horizontal = 24.dp),
                 )
+                Spacer(modifier = Modifier.height(32.dp))
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/MainScreen.kt
@@ -1,0 +1,168 @@
+package org.moneyking.imagepicker.screen
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.setSingletonImageLoaderFactory
+import dev.icerock.moko.resources.compose.fontFamilyResource
+import dev.icerock.moko.resources.compose.stringResource
+import org.moneyking.imagepicker.MR
+import org.moneyking.imagepicker.component.HorizontalPagerIndicator
+import org.moneyking.imagepicker.component.ImageCard
+import org.moneyking.imagepicker.component.ImagePickerButton
+import org.moneyking.imagepicker.launcher.SelectionMode
+import org.moneyking.imagepicker.launcher.rememberImagePickerLauncher
+import org.moneyking.imagepicker.navigation.MainScreenComponent
+import org.moneyking.imagepicker.navigation.MainScreenEvent
+import org.moneyking.imagepicker.util.newImageLoader
+
+@OptIn(
+    ExperimentalFoundationApi::class, ExperimentalCoilApi::class,
+    ExperimentalMaterial3Api::class
+)
+@Composable
+fun MainScreen(
+    component: MainScreenComponent,
+    modifier: Modifier = Modifier,
+    debug: Boolean = false
+) {
+    setSingletonImageLoaderFactory { context ->
+        newImageLoader(context, debug)
+    }
+    val scope = rememberCoroutineScope()
+    var images by remember { mutableStateOf(listOf<ByteArray>()) }
+    val singlePhotoPicker = rememberImagePickerLauncher(
+        selectionMode = SelectionMode.Single,
+        scope = scope,
+        onResult = { imageData ->
+            images = imageData
+            component.onEvent(MainScreenEvent.UpdateImageList(imageData))
+        }
+    )
+    val multiplePhotoPicker = rememberImagePickerLauncher(
+        selectionMode = SelectionMode.Multiple,
+        scope = scope,
+        onResult = { imageDataList ->
+            images = imageDataList
+            component.onEvent(MainScreenEvent.UpdateImageList(imageDataList))
+        }
+    )
+
+    MaterialTheme {
+        // val pageCount = component.imageList.value.size
+        val pageCount = images.size
+        val pagerState = rememberPagerState(pageCount = { pageCount })
+        val pagerHeight = 320.dp
+
+        Scaffold(
+            modifier = modifier.fillMaxSize(),
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(MR.strings.main),
+                            fontFamily = fontFamilyResource(MR.fonts.Pretendard.semiBold),
+                            fontWeight = FontWeight.SemiBold,
+                            fontStyle = FontStyle.Normal,
+                        )
+                    },
+                )
+            }
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                // if (component.imageList.value.isNotEmpty()) {
+                if (images.isNotEmpty()) {
+                    HorizontalPager(
+                        state = pagerState,
+                        modifier = Modifier.height(pagerHeight),
+                        contentPadding = PaddingValues(horizontal = 32.dp),
+                    ) { index ->
+                        // val image = component.imageList.value[index]
+                        val image = images[index]
+                        ImageCard(
+                            image = image,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clickable {
+                                    component.onEvent(MainScreenEvent.UpdateImageIndex(index))
+                                    component.onEvent(MainScreenEvent.ClickImageCard(image))
+                                },
+                        )
+                    }
+                    if (pageCount > 1) {
+                        HorizontalPagerIndicator(
+                            pageCount = pageCount,
+                            currentPage = pagerState.currentPage,
+                            targetPage = pagerState.targetPage,
+                            currentPageOffsetFraction = pagerState.currentPageOffsetFraction,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(32.dp))
+                }
+                ImagePickerButton(
+                    onClick = {
+                        singlePhotoPicker.launch()
+                    },
+                    text = stringResource(MR.strings.pick_single_image),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .padding(horizontal = 24.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                ImagePickerButton(
+                    onClick = {
+                        multiplePhotoPicker.launch()
+                    },
+                    text = stringResource(MR.strings.pick_multiple_images),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .padding(horizontal = 24.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                ImagePickerButton(
+                    onClick = {
+                        images = emptyList()
+                        component.onEvent(MainScreenEvent.UpdateImageList(emptyList()))
+                    },
+                    text = stringResource(MR.strings.reset),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .padding(horizontal = 24.dp),
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/moneyking/imagepicker/screen/MainScreen.kt
@@ -21,10 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
@@ -32,6 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.setSingletonImageLoaderFactory
+import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
 import dev.icerock.moko.resources.compose.fontFamilyResource
 import dev.icerock.moko.resources.compose.stringResource
 import org.moneyking.imagepicker.MR
@@ -58,13 +56,12 @@ fun MainScreen(
     setSingletonImageLoaderFactory { context ->
         newImageLoader(context, debug)
     }
+    val imageList by component.imageList.subscribeAsState()
     val scope = rememberCoroutineScope()
-    var images by remember { mutableStateOf(listOf<ByteArray>()) }
     val singlePhotoPicker = rememberImagePickerLauncher(
         selectionMode = SelectionMode.Single,
         scope = scope,
         onResult = { imageData ->
-            images = imageData
             component.onEvent(MainScreenEvent.UpdateImageList(imageData))
         }
     )
@@ -72,14 +69,12 @@ fun MainScreen(
         selectionMode = SelectionMode.Multiple,
         scope = scope,
         onResult = { imageDataList ->
-            images = imageDataList
             component.onEvent(MainScreenEvent.UpdateImageList(imageDataList))
         }
     )
 
     MaterialTheme {
-        // val pageCount = component.imageList.value.size
-        val pageCount = images.size
+        val pageCount = imageList.size
         val pagerState = rememberPagerState(pageCount = { pageCount })
         val pagerHeight = 320.dp
 
@@ -106,15 +101,13 @@ fun MainScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
-                // if (component.imageList.value.isNotEmpty()) {
-                if (images.isNotEmpty()) {
+                if (imageList.isNotEmpty()) {
                     HorizontalPager(
                         state = pagerState,
                         modifier = Modifier.height(pagerHeight),
                         contentPadding = PaddingValues(horizontal = 32.dp),
                     ) { index ->
-                        // val image = component.imageList.value[index]
-                        val image = images[index]
+                        val image = imageList[index]
                         ImageCard(
                             image = image,
                             modifier = Modifier
@@ -161,7 +154,6 @@ fun MainScreen(
                 Spacer(modifier = Modifier.height(16.dp))
                 ImagePickerButton(
                     onClick = {
-                        images = emptyList()
                         component.onEvent(MainScreenEvent.UpdateImageList(emptyList()))
                     },
                     text = stringResource(MR.strings.reset),

--- a/composeApp/src/commonMain/resources/MR/base/strings.xml
+++ b/composeApp/src/commonMain/resources/MR/base/strings.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
+    <string name="main">메인 화면</string>
     <string name="pick_single_image">사진 한 장 선택하기</string>
     <string name="pick_multiple_images">사진 여러 장 선택하기</string>
     <string name="reset">초기화</string>
+    <string name="gallery_image">갤러리 사진</string>
+    <string name="image_card">사진 카드</string>
+    <string name="detail">상세 화면</string>
+    <string name="back_button">뒤로가기 버튼</string>
+    <string name="detail_image">상세 이미지</string>
 </resources>

--- a/composeApp/src/commonMain/resources/MR/en/strings.xml
+++ b/composeApp/src/commonMain/resources/MR/en/strings.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
+    <string name="main">Main Screen</string>
     <string name="pick_single_image">Pick Single Images</string>
     <string name="pick_multiple_images">Pick Multiple Images</string>
     <string name="reset">Init</string>
+    <string name="gallery_image">Gallery Image</string>
+    <string name="image_card">Image Card</string>
+    <string name="detail">Detail Screen</string>
+    <string name="back_button">Back Button</string>
+    <string name="detail_image">Detail Image</string>
 </resources>

--- a/composeApp/src/desktopMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/desktopMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 
 @Composable
 actual fun rememberImagePickerLauncher(
-    onResult: (List<Any>) -> Unit,
+    onResult: (List<ByteArray>) -> Unit,
     scope: CoroutineScope?,
     selectionMode: SelectionMode,
 ): ImagePickerLauncher {

--- a/composeApp/src/desktopMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/desktopMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 @Composable
 actual fun rememberImagePickerLauncher(
     onResult: (List<ByteArray>) -> Unit,
-    scope: CoroutineScope?,
+    scope: CoroutineScope,
     selectionMode: SelectionMode,
 ): ImagePickerLauncher {
     TODO()

--- a/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/MainViewController.kt
@@ -1,5 +1,14 @@
 package org.moneyking.imagepicker
 
+import androidx.compose.runtime.remember
 import androidx.compose.ui.window.ComposeUIViewController
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import org.moneyking.imagepicker.navigation.RootComponent
 
-fun MainViewController() = ComposeUIViewController { App() }
+fun MainViewController() = ComposeUIViewController {
+    val root = remember {
+        RootComponent(DefaultComponentContext(LifecycleRegistry()))
+    }
+    App(root)
+}

--- a/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -30,7 +30,7 @@ import platform.posix.memcpy
 @Composable
 actual fun rememberImagePickerLauncher(
     onResult: (List<ByteArray>) -> Unit,
-    scope: CoroutineScope?,
+    scope: CoroutineScope,
     selectionMode: SelectionMode,
 ): ImagePickerLauncher {
     @OptIn(ExperimentalForeignApi::class)
@@ -52,7 +52,7 @@ actual fun rememberImagePickerLauncher(
                     result.itemProvider.loadDataRepresentationForTypeIdentifier(
                         typeIdentifier = "public.image",
                     ) { nsData, _ ->
-                        scope?.launch(Dispatchers.Main) {
+                        scope.launch(Dispatchers.Main) {
                             nsData?.let {
                                 val bytes = ByteArray(it.length.toInt())
                                 memcpy(bytes.refTo(0), it.bytes, it.length)
@@ -64,7 +64,7 @@ actual fun rememberImagePickerLauncher(
                 }
 
                 dispatch_group_notify(dispatchGroup, dispatch_get_main_queue()) {
-                    scope?.launch(Dispatchers.Main) {
+                    scope.launch(Dispatchers.Main) {
                         onResult(imageData)
                     }
                 }

--- a/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
+++ b/composeApp/src/iosMain/kotlin/org/moneyking/imagepicker/launcher/ImagePickerLauncher.kt
@@ -29,7 +29,7 @@ import platform.posix.memcpy
 
 @Composable
 actual fun rememberImagePickerLauncher(
-    onResult: (List<Any>) -> Unit,
+    onResult: (List<ByteArray>) -> Unit,
     scope: CoroutineScope?,
     selectionMode: SelectionMode,
 ): ImagePickerLauncher {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,10 @@ hiltVersion = "2.47"
 hiltCompilerVersion = "1.1.0"
 napier = "2.6.1"
 moko-resources = "0.23.0"
+decompose = "2.2.2"
+extensionsComposeJetbrains = "2.1.4-compose-experimental"
+kotlinxSerializationJson = "1.6.1"
+zoomable = "1.6.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -39,6 +43,7 @@ compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
+androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
 compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
 coil-network = { module = "io.coil-kt.coil3:coil-network", version.ref = "coil3" }
@@ -55,12 +60,17 @@ napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 moko-resources-generator = { group = "dev.icerock.moko", name = "resources-generator", version.ref = "moko-resources" }
 moko-resource = { group = "dev.icerock.moko", name = "resources", version.ref = "moko-resources" }
 moko-resource-compose = { group = "dev.icerock.moko", name = "resources-compose", version.ref = "moko-resources" }
+decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
+decompose-jetbrains = { module = "com.arkivanov.decompose:extensions-compose-jetbrains", version.ref = "extensionsComposeJetbrains" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+zoomable = { module = "com.mxalbert.zoomable:zoomable", version.ref = "zoomable"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 [bundles]
 moko-resources = ["moko-resource", "moko-resource-compose"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.1.4"
+kotlin = "1.9.21"
 android-compileSdk = "34"
 android-minSdk = "24"
 android-targetSdk = "34"
@@ -15,55 +16,48 @@ compose-compiler = "1.5.6"
 compose-material3 = "1.1.2"
 compose-plugin = "1.5.11"
 junit = "4.13.2"
-kotlin = "1.9.21"
 coil3 = "3.0.0-alpha01"
 ktor = "2.3.7"
-hiltVersion = "2.47"
-hiltCompilerVersion = "1.1.0"
 napier = "2.6.1"
 moko-resources = "0.23.0"
 decompose = "2.2.2"
-extensionsComposeJetbrains = "2.1.4-compose-experimental"
-kotlinxSerializationJson = "1.6.1"
+extensions-compose-jetbrains = "2.1.4-compose-experimental"
+kotlinx-serialization-json = "1.6.1"
 zoomable = "1.6.1"
 
 [libraries]
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso-core" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
+compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" }
-coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
-coil-network = { module = "io.coil-kt.coil3:coil-network", version.ref = "coil3" }
-ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-engine-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
-ktor-engine-ios = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
-ktor-engine-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }
+coil-network = { group = "io.coil-kt.coil3", name = "coil-network", version.ref = "coil3" }
+ktor-client-core = { group = "io.ktor", name = " ktor-client-core", version.ref = "ktor" }
+ktor-engine-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
+ktor-engine-ios = { group = "io.ktor", name = "ktor-client-ios", version.ref = "ktor" }
+ktor-engine-js = { group = "io.ktor", name = "ktor-client-js", version.ref = "ktor" }
 
-hiltAndroid = { module = "com.google.dagger:hilt-android", version.ref = "hiltVersion" }
-hiltAndroidCompiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltVersion" }
-hiltCompiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltCompilerVersion" }
-hiltNavigationCompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltCompilerVersion" }
-napier = { module = "io.github.aakira:napier", version.ref = "napier" }
+napier = { group = "io.github.aakira", name = "napier", version.ref = "napier" }
 moko-resources-generator = { group = "dev.icerock.moko", name = "resources-generator", version.ref = "moko-resources" }
 moko-resource = { group = "dev.icerock.moko", name = "resources", version.ref = "moko-resources" }
 moko-resource-compose = { group = "dev.icerock.moko", name = "resources-compose", version.ref = "moko-resources" }
-decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
-decompose-jetbrains = { module = "com.arkivanov.decompose:extensions-compose-jetbrains", version.ref = "extensionsComposeJetbrains" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
-zoomable = { module = "com.mxalbert.zoomable:zoomable", version.ref = "zoomable"}
+decompose = { group = "com.arkivanov.decompose", name = "decompose", version.ref = "decompose" }
+decompose-jetbrains = { group = "com.arkivanov.decompose", name = "extensions-compose-jetbrains", version.ref = "extensions-compose-jetbrains" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+zoomable = { group = "com.mxalbert.zoomable", name = "zoomable", version.ref = "zoomable" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -17,5 +17,3 @@ struct ContentView: View {
     }
 }
 
-
-


### PR DESCRIPTION
- [Decompose](https://arkivanov.github.io/Decompose/) 라이브러리를 사용하여 Navigation, AAC ViewModel(State holder) 의 역할을 하는 클래스들 추가하였습니다.
- 상세 화면 추가을 추가하였습니다.
- 메인 화면 내에 이미지를 클릭하면 상세 화면으로 진입(DecomposeNavigation)
- 상세 화면에선 메인화면에서 전달받은 이미지를 줌을 통해 확대해서 볼 수 있습니다.(Zoomable 라이브러리 적용)
- Android 와 iOS 사진 type ByteArray 로 통일시켰습니다.(Decompose Navigation 을 통해 상세 화면으로 데이터를 넘길 때, argument 의 type 을 하나로 통일 시키기 위함)
- MainScreen 내에 imageList<ByteArray> 를 사용하는 것이 아닌 MainScreenComponent(MainScreen의 ViewModel의 역할) 내의 imageList<ByteArray> 를 이용하여 가져온 사진 목록을 관리 (상세 화면에 갔다가 다시 돌아와도, imageList가 유지되도록) 하는 방식으로 리팩토링 하였습니다.
- coil3 을 이용한 UriToByteArray 함수를 사용하는 방식으로 변경하였습니다.
